### PR TITLE
调整 build 频率

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,7 +2,7 @@ name: Build geoip.dat
 
 on: 
   schedule:
-    - cron: "0 1 * * *"
+    - cron: "0 1 */4 * *"
   push:
     branches:
       - master


### PR DESCRIPTION
The GeoLite2 Country, City, and ASN databases are updated weekly, every Tuesday.

GitHub 自己倒是整的很清楚，这个 Action 会发生在 UTC 时间。但是 MaxMind 那边到底会在哪个时区的周二几点更新数据库就不清楚了。
我的考虑是让最坏的情况也只比上游晚 3 天更新 geoip.dat 文件，本来用免费数据库的精度也就那样，更新频率不用那么频繁也没关系。每 4 天更新一次也算凑整了。