### PR TITLE
Update workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -36,6 +36,10 @@ jobs:
           go get -u -v -insecure $REPO_URL
           geoip --country=./geoip/GeoLite2-Country-Locations-en.csv --ipv4=./geoip/GeoLite2-Country-Blocks-IPv4.csv --ipv6=./geoip/GeoLite2-Country-Blocks-IPv6.csv
 
+      - name: Generate geoip.dat sha256 hash
+        run: |
+          sha256sum geoip.dat > geoip.dat.sha256sum
+
       - name: Create a release
         id: create_release
         uses: actions/create-release@v1
@@ -47,7 +51,7 @@ jobs:
           draft: false
           prerelease: false
 
-      - name: Upload dat file
+      - name: Upload geoip.dat
         id: upload-release-asset 
         uses: actions/upload-release-asset@v1
         env:
@@ -57,3 +61,14 @@ jobs:
           asset_path: ./geoip.dat
           asset_name: geoip.dat
           asset_content_type: application/octet-stream
+
+      - name: Upload geoip.dat sha256sum
+        id: upload-release-asset 
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./geoip.dat.sha256sum
+          asset_name: geoip.dat.sha256sum
+          asset_content_type: text/plain

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -40,6 +40,17 @@ jobs:
         run: |
           sha256sum geoip.dat > geoip.dat.sha256sum
 
+      - name: Git push assets to "release" branch
+        run: |
+          git init
+          git config --local user.name "${{ github.actor }}"
+          git config --local user.email "${{ github.actor }}@users.noreply.github.com"
+          git checkout -b release
+          git add geoip.dat geoip.dat.sha256sum
+          git commit -m "${{ env.RELEASE_NAME }}"
+          git remote add origin "https://${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}"
+          git push -f -u origin release
+
       - name: Create a release
         id: create_release
         uses: actions/create-release@v1
@@ -52,7 +63,6 @@ jobs:
           prerelease: false
 
       - name: Upload geoip.dat
-        id: upload-release-asset 
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -63,7 +73,6 @@ jobs:
           asset_content_type: application/octet-stream
 
       - name: Upload geoip.dat sha256sum
-        id: upload-release-asset 
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -3,3 +3,8 @@
 Automatically weekly release of geoip.dat for V2Ray.
 
 This product includes GeoLite2 data created by MaxMind, available from [MaxMind](http://www.maxmind.com/).
+
+## Download links
+
+- **geoip.dat**：[https://github.com/v2ray/geoip/raw/release/geoip.dat](https://github.com/v2ray/geoip/raw/release/geoip.dat)
+- **geoip.dat.sha256sum**：[https://github.com/v2ray/geoip/raw/release/geoip.dat.sha256sum](https://github.com/v2ray/geoip/raw/release/geoip.dat.sha256sum)


### PR DESCRIPTION
- generate `geoip.dat` sha256 hash file `geoip.dat.sha256sum`
- push `geoip.dat` & `geoip.dat.sha256sum` to release branch due to #18 